### PR TITLE
fix(i18n): correct translator comments position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.3.1] - 2025-01-06
+
+### Fixed
+- **📝 Translator Comments Position**: Corrected position of translator comments to be immediately before `esc_html__()` calls instead of before `sprintf()` (5 instances)
+  - Line 1656-1657: Database column/table suspicious detection
+  - Line 1704-1705: Suspicious post ID/title detection
+  - Line 1793-1794: Missing core file detection
+  - Line 1799-1800: Suspicious core file detection
+  - Line 1827-1828: Incorrect file permissions detection
+
+### Technical
+- Translator comments must be placed directly before the translation function call per WordPress Coding Standards
+- This ensures proper extraction and context for translators in POT file generation
+
 ## [1.3.0] - 2025-01-06
 
 ### Fixed - WordPress.org Compliance
@@ -237,6 +251,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version History
 
+- **1.3.1** - Translator comments position fix for WPCS compliance
 - **1.3.0** - WordPress.org coding standards compliance, security escaping, and translation improvements
 - **1.2.0** - Unregistered plugin folder detection, intelligent plugin verification, and UI improvements
 - **1.1.0** - Advanced heuristic analysis, duplicate detection, typosquatting detection, and smart false positive reduction

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Plugin de emergencia para limpieza automática de malware después del compromiso del servidor**
 
-[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](https://github.com/aredos/emergency-cleanup)
+[![Version](https://img.shields.io/badge/version-1.3.1-blue.svg)](https://github.com/aredos/emergency-cleanup)
 [![WordPress](https://img.shields.io/badge/WordPress-5.0%2B-blue.svg)](https://wordpress.org/)
 [![PHP](https://img.shields.io/badge/PHP-7.4%2B-green.svg)](https://php.net/)
 [![License](https://img.shields.io/badge/license-GPL%20v2-orange.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -613,7 +613,7 @@ Para soporte técnico:
 
 Para ver el historial completo de cambios y versiones, consulta el archivo **[CHANGELOG.md](CHANGELOG.md)**.
 
-### Última Versión: **1.3.0**
+### Última Versión: **1.3.1**
 
 **✅ Cumplimiento WordPress.org Coding Standards**
 - Correcciones de Text Domain

--- a/emergency-cleanup.php
+++ b/emergency-cleanup.php
@@ -3,7 +3,7 @@
  * Plugin Name: Emergency Security Cleanup
  * Plugin URI: https://github.com/aredos/emergency-cleanup
  * Description: Plugin de emergencia para limpieza automática de malware después del compromiso del servidor. Incluye detección avanzada, backup automático y verificación de integridad.
- * Version: 1.3.0
+ * Version: 1.3.1
  * Requires at least: 5.0
  * Tested up to: 6.7
  * Requires PHP: 7.4
@@ -32,7 +32,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Definir constantes del plugin
-define('EMERGENCY_CLEANUP_VERSION', '1.3.0');
+define('EMERGENCY_CLEANUP_VERSION', '1.3.1');
 define('EMERGENCY_CLEANUP_PLUGIN_FILE', __FILE__);
 define('EMERGENCY_CLEANUP_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('EMERGENCY_CLEANUP_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -1652,8 +1652,8 @@ class EmergencySecurityCleanup {
                 foreach ($columns as $column) {
                     $field_name = sanitize_text_field($column['Field']);
                     if (preg_match('/eval|base64|shell|exec|system/i', $field_name)) {
-                        // translators: %1$s is the suspicious column name, %2$s is the table name
                         $issues[] = sprintf(
+                            // translators: %1$s is the suspicious column name, %2$s is the table name
                             esc_html__('Columna sospechosa "%1$s" en tabla "%2$s"', 'Emergency_Cleanup'),
                             esc_html($field_name),
                             esc_html($table_name)
@@ -1700,8 +1700,8 @@ class EmergencySecurityCleanup {
                         $is_malicious = $this->verify_malicious_post_content($post->post_content);
                         
                         if ($is_malicious) {
-                            // translators: %1$d is the post ID, %2$s is the post title
                             $issues[] = sprintf(
+                                // translators: %1$d is the post ID, %2$s is the post title
                                 esc_html__('Post sospechoso ID %1$d: %2$s', 'Emergency_Cleanup'),
                                 intval($post->ID),
                                 esc_html($post->post_title)
@@ -1789,14 +1789,14 @@ class EmergencySecurityCleanup {
         foreach ($core_files as $file) {
             $file_path = ABSPATH . $file;
             if (!file_exists($file_path)) {
-                // translators: %s is the missing core file name
                 $issues[] = sprintf(
+                    // translators: %s is the missing core file name
                     esc_html__('Archivo core faltante: %s', 'Emergency_Cleanup'),
                     esc_html($file)
                 );
             } elseif (filesize($file_path) < 100) {
-                // translators: %s is the suspicious core file name
                 $issues[] = sprintf(
+                    // translators: %s is the suspicious core file name
                     esc_html__('Archivo core sospechoso (muy pequeño): %s', 'Emergency_Cleanup'),
                     esc_html($file)
                 );
@@ -1823,8 +1823,8 @@ class EmergencySecurityCleanup {
             if (file_exists($file_path)) {
                 $actual_perms = fileperms($file_path) & 0777;
                 if ($actual_perms !== $expected_perms) {
-                    // translators: %1$s is the file name, %2$o is the actual permissions, %3$o is the expected permissions
                     $issues[] = sprintf(
+                        // translators: %1$s is the file name, %2$o is the actual permissions, %3$o is the expected permissions
                         esc_html__('Permisos incorrectos en %1$s (actual: %2$o, esperado: %3$o)', 'Emergency_Cleanup'),
                         esc_html($file),
                         $actual_perms,

--- a/languages/emergency-cleanup.pot
+++ b/languages/emergency-cleanup.pot
@@ -1,10 +1,10 @@
-# Copyright (C) 2024 Aredos
+# Copyright (C) 2025 Aredos
 # This file is distributed under the same license as the Emergency Security Cleanup package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Emergency Security Cleanup 1.0.0\n"
+"Project-Id-Version: Emergency Security Cleanup 1.3.1\n"
 "Report-Msgid-Bugs-To: https://github.com/aredos/emergency-cleanup/issues\n"
-"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"POT-Creation-Date: 2025-01-06 12:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
Moved translator comments to be immediately before esc_html__() calls instead of before sprintf() to meet WordPress Coding Standards requirements.

Fixed 5 instances:
- Database column/table detection (line 1656-1657)
- Suspicious post detection (line 1704-1705)
- Missing core file (line 1793-1794)
- Suspicious core file (line 1799-1800)
- Incorrect file permissions (line 1827-1828)

Version: 1.3.1